### PR TITLE
Update liquid shared templates to match output with SMRL repository

### DIFF
--- a/_basic_title.liquid
+++ b/_basic_title.liquid
@@ -7,8 +7,8 @@
 {% endif %}
 {% endif %}
 [[{{thing_prefix}}.{{anchor | replace: "\", "-"}}]]
-[level={{xdepth}}]
-{{equalsigns}} {{ title | replace: "\", "-" }}
+[level={{xdepth}},type=express]
+{{equalsigns}} {{ title | replace: "\", "-" }} ((({{ anchor }},Object definition)))
 
 //equalsigns: {{equalsigns}}
 //

--- a/_body.liquid
+++ b/_body.liquid
@@ -22,3 +22,10 @@ The following EXPRESS declaration begins the *{{ thing.id }}* and identifies the
 {% render "templates/body_remarks", remark_items: thing.remark_items %}
 
 {% render "templates/body_source_code", source: thing.source %}
+
+
+{% if schema_description %}
+
+NOTE: See <<expg.{{ thing.id }}>> for a graphical representation of this schema.
+
+{% endif %}

--- a/_body.liquid
+++ b/_body.liquid
@@ -1,6 +1,24 @@
 
 {{ thing.remarks }}
 
+{% if schema_description %}
+{% assign schema_remark = thing.remarks %}
+{% comment %}
+This is purely for the bug at
+https://github.com/lutaml/expressir/issues/108
+
+Once that is fixed the following IF statement should be removed and just use {{ thing.remarks }}
+{% endcomment %}
+
+{% if schema_remark.size == 0 %}
+{% assign schema_remark = thing.remark_items | where: "id", thing.id | first %}
+{% endif %}
+
+{{ schema_remark.remarks }}
+
+The following EXPRESS declaration begins the *{{ thing.id }}* and identifies the necessary external references.
+{% endif %}
+
 {% render "templates/body_remarks", remark_items: thing.remark_items %}
 
 {% render "templates/body_source_code", source: thing.source %}

--- a/_entities.liquid
+++ b/_entities.liquid
@@ -6,7 +6,7 @@
 {% for thing in things %}
 {% assign entity_nested_depth = depth | plus: 1 %}
 
-{% render "templates/entity", thing: thing, thing_prefix: thing_prefix, depth: entity_nested_depth %}
+{% render "templates/entity", schema: schema, thing: thing, thing_prefix: thing_prefix, depth: entity_nested_depth %}
 
 {% endfor %}
 

--- a/_entity.liquid
+++ b/_entity.liquid
@@ -1,7 +1,16 @@
 {% assign entity_nested_depth = depth %}
 {% render "templates/basic_thing", depth: entity_nested_depth, thing_prefix: thing_prefix, thing: thing %}
 
-{% if thing.attributes.size > 0 %}
+{% render "templates/entity_subtype_constraints", subtypes: schema.subtype_constraints, entity_id: thing.id %}
+
+{% assign found = false %}
+{% for attribute in thing.attributes %}
+{% if attribute.remarks.size > 0 %}
+{% assign found = true %}
+{% endif %}
+{% endfor %}
+
+{% if thing.attributes.size > 0 and found %}
 {% capture entity_thing_prefix %}{{thing_prefix}}.{{thing.id}}{% endcapture %}
 
 {% render "templates/entity_attributes", things: thing.attributes, thing_prefix: entity_thing_prefix, depth: entity_nested_depth %}

--- a/_entity.liquid
+++ b/_entity.liquid
@@ -17,6 +17,13 @@
 
 {% endif %}
 
+{% if thing.remark_items.size > 0 %}
+{% capture entity_thing_prefix %}{{thing_prefix}}.{{thing.id}}{% endcapture %}
+
+{% render "templates/entity_attributes", things: thing.remark_items, thing_prefix: entity_thing_prefix, depth: entity_nested_depth, found: found %}
+
+{% endif %}
+
 {% if thing.where_rules.size > 0 %}
 {% capture entity_thing_prefix %}{{thing_prefix}}.{{thing.id}}{% endcapture %}
 

--- a/_entity_attributes.liquid
+++ b/_entity_attributes.liquid
@@ -1,11 +1,15 @@
 {% if things.size > 0 %}
 {% assign ea_nested_depth = depth %}
 
+{% unless found %}
 [underline]#Attribute definitions:#
+{% endunless %}
 
 {% for thing in things %}
 
+{% if thing.remarks.size > 0 %}
 **{{ thing.id }}**:: {{ thing.remarks }}
+{% endif %}
 
 {% render "templates/body_remarks", remark_items: thing.remark_items %}
 

--- a/_entity_informal_propositions.liquid
+++ b/_entity_informal_propositions.liquid
@@ -1,4 +1,11 @@
-{% if things.size > 0 %}
+{% assign found = false %}
+{% for thing in things %}
+{% if thing.remarks.size > 0 %}
+{% assign found = true %}
+{% endif %}
+{% endfor %}
+
+{% if things.size > 0 and found %}
 {% assign ea_nested_depth = depth %}
 
 [underline]#Informal propositions:#

--- a/_entity_subtype_constraints.liquid
+++ b/_entity_subtype_constraints.liquid
@@ -1,0 +1,14 @@
+
+{% if subtypes.size > 0 %}
+{% for constraint in subtypes %}
+
+{% if constraint.applies_to.id == entity_id %}
+
+[source%unnumbered]
+--
+{{ constraint.source }}
+--
+{% endif %}
+
+{% endfor %}
+{% endif %}

--- a/_entity_unique_rules.liquid
+++ b/_entity_unique_rules.liquid
@@ -1,11 +1,20 @@
-{% if things.size > 0 %}
+{% assign found = false %}
+{% for thing in things %}
+{% if thing.remarks.size > 0 %}
+{% assign found = true %}
+{% endif %}
+{% endfor %}
+
+{% if things.size > 0 and found %}
 {% assign ea_nested_depth = depth %}
 
 [underline]#Formal propositions (unique rules):#
 
 {% for thing in things %}
 
+{% if thing.remarks.size > 0 %}
 **{{ thing.id }}**:: {{ thing.remarks }}
+{% endif %}
 
 {% render "templates/body_remarks", remark_items: thing.remark_items %}
 

--- a/_entity_where_rules.liquid
+++ b/_entity_where_rules.liquid
@@ -1,11 +1,20 @@
-{% if things.size > 0 %}
+{% assign found = false %}
+{% for thing in things %}
+{% if thing.remarks.size > 0 %}
+{% assign found = true %}
+{% endif %}
+{% endfor %}
+
+{% if things.size > 0 and found %}
 {% assign ea_nested_depth = depth %}
 
 [underline]#Formal propositions:#
 
 {% for thing in things %}
 
+{% if thing.remarks.size > 0 %}
 **{{ thing.id }}**:: {{ thing.remarks }}
+{% endif %}
 
 {% render "templates/body_remarks", remark_items: thing.remark_items %}
 

--- a/_function.liquid
+++ b/_function.liquid
@@ -1,25 +1,40 @@
-{% capture function_thing_prefix %}{{thing_prefix}}.{{thing.id}}{% endcapture %}
+{% capture function_thing_prefix %}{{thing_prefix}}{% endcapture %}
 
 {% render "templates/basic_thing", depth: depth, thing_prefix: function_thing_prefix, thing: thing %}
 
 {% assign function_nested_depth = depth | plus: 1%}
 
+{% assign found = false %}
+
 {% if thing.parameters.size > 0 %}
 {% render "templates/function_parameters", things: thing.parameters, thing_prefix: function_thing_prefix, depth: function_nested_depth %}
+
+{% assign found = true %}
 
 {% endif %}
 
 {% if thing.types.size > 0 %}
-{% render "templates/function_parameters", things: thing.types, thing_prefix: function_thing_prefix, depth: function_nested_depth %}
+{% render "templates/function_parameters", things: thing.types, thing_prefix: function_thing_prefix, depth: function_nested_depth, found: found %}
+
+{% assign found = true %}
 
 {% endif %}
 
 {% if thing.constants.size > 0 %}
-{% render "templates/function_constants", things: thing.constants, thing_prefix: function_thing_prefix, depth: function_nested_depth %}
+{% render "templates/function_constants", things: thing.constants, thing_prefix: function_thing_prefix, depth: function_nested_depth, found: found %}
+
+{% assign found = true %}
 
 {% endif %}
 
 {% if thing.variables.size > 0 %}
-{% render "templates/function_variables", things: thing.variables, thing_prefix: function_thing_prefix, depth: function_nested_depth %}
+{% render "templates/function_variables", things: thing.variables, thing_prefix: function_thing_prefix, depth: function_nested_depth, found: found %}
+
+{% assign found = true %}
+
+{% endif %}
+
+{% if thing.remark_items.size > 0 %}
+{% render "templates/function_variables", things: thing.remark_items, thing_prefix: function_thing_prefix, depth: function_nested_depth, found: found %}
 
 {% endif %}

--- a/_function_constants.liquid
+++ b/_function_constants.liquid
@@ -1,11 +1,15 @@
 {% if things.size > 0 %}
 {% assign fc_nested_depth = depth %}
 
+{% unless found %}
 [underline]#Argument definitions:#
+{% endunless %}
 
 {% for thing in things %}
 
+{% if thing.remarks.size > 0 %}
 **{{ thing.id }}**:: {{ thing.remarks }}
+{% endif %}
 
 {% render "templates/body_remarks", remark_items: thing.remark_items %}
 

--- a/_function_parameters.liquid
+++ b/_function_parameters.liquid
@@ -1,11 +1,15 @@
 {% if things.size > 0 %}
 {% assign fp_nested_depth = depth %}
 
+{% unless found %}
 [underline]#Argument definitions:#
+{% endunless %}
 
 {% for thing in things %}
 
+{% if thing.remarks.size > 0 %}
 **{{ thing.id }}**:: {{ thing.remarks }}
+{% endif %}
 
 {% render "templates/body_remarks", remark_items: thing.remark_items %}
 

--- a/_function_variables.liquid
+++ b/_function_variables.liquid
@@ -1,11 +1,15 @@
 {% if things.size > 0 %}
 {% assign fv_nested_depth = depth %}
 
+{% unless found %}
 [underline]#Argument definitions:#
+{% endunless %}
 
 {% for thing in things %}
 
+{% if thing.remarks.size > 0 %}
 **{{ thing.id }}**:: {{ thing.remarks }}
+{% endif %}
 
 {% render "templates/body_remarks", remark_items: thing.remark_items %}
 

--- a/_fund_cons.liquid
+++ b/_fund_cons.liquid
@@ -6,7 +6,7 @@
 {% capture equalsigns %}{% for count in (1..xdepth) %}={% endfor %}{% endcapture %}
 {% endif %}
 {% endif %}
-[[{{thing_prefix}}.{{anchor | replace: "\", "-"}}]]
+[[{{thing_prefix}}_funds]]
 [level={{xdepth}}]
 {{equalsigns}} Fundamental concepts and assumptions
 

--- a/_schema.liquid
+++ b/_schema.liquid
@@ -6,7 +6,7 @@
 
 === General
 
-{% render "templates/body", thing: schema %}
+{% render "templates/body", thing: schema, schema_description: true %}
 
 {% render "templates/fund_cons", thing: schema, thing_prefix: root_thing_prefix, depth: 2 %}
 

--- a/_schema.liquid
+++ b/_schema.liquid
@@ -14,7 +14,7 @@
 
 {% render "templates/types", schema_id: schema.id, things: schema.types, thing_prefix: root_thing_prefix, depth: 2 %}
 
-{% render "templates/entities", schema_id: schema.id, things: schema.entities, thing_prefix: root_thing_prefix, depth: 2 %}
+{% render "templates/entities", schema: schema, schema_id: schema.id, things: schema.entities, thing_prefix: root_thing_prefix, depth: 2 %}
 
 {% render "templates/subtype_constraints", schema_id: schema.id, things: schema.subtype_constraints, thing_prefix: root_thing_prefix, depth: 2 %}
 

--- a/_schema.liquid
+++ b/_schema.liquid
@@ -1,4 +1,4 @@
-{% capture root_thing_prefix %}{{anchor-prefix}}{{schema.id}}{% endcapture %}
+{% capture root_thing_prefix %}{{schema.id}}{% endcapture %}
 
 [[{{root_thing_prefix}}]]
 [type="express-schema"]

--- a/_schema.liquid
+++ b/_schema.liquid
@@ -23,3 +23,10 @@
 {% render "templates/procedures", schema_id: schema.id, things: schema.procedures, thing_prefix: root_thing_prefix, depth: 2 %}
 
 {% render "templates/rules", schema_id: schema.id, things: schema.rules, thing_prefix: root_thing_prefix, depth: 2 %}
+
+[underline]#EXPRESS specification:#
+
+[source%unnumbered]
+--
+END_SCHEMA; -- {{ schema.id }}
+--


### PR DESCRIPTION
In https://github.com/metanorma/iso-10303-detached-docs/issues/259

There is still one main difference that I don't know how to address: *The generation of the first NOTE in the schema description*. 
The first NOTE is to contain a list of references that are to be taken from external schemas. I'm not sure how to achieve this using liquid. There is an open ticket related to this: https://github.com/metanorma/annotated-express/issues/138

Further comments:
- `SELF\` prefixed definitions do not show up in output. See https://github.com/metanorma/iso-10303-detached-docs/issues/232.
- I don't think the "templates" symbolic link within every "sections" folder is required.