### PR TITLE
Add cross-references to EXPRESS-G diagrams

### DIFF
--- a/_basic_title.liquid
+++ b/_basic_title.liquid
@@ -8,7 +8,7 @@
 {% endif %}
 [[{{thing_prefix}}.{{anchor | replace: "\", "-"}}]]
 [level={{xdepth}},type=express]
-{{equalsigns}} {{ title | replace: "\", "-" }} ((({{ anchor }},Object definition)))
+{{equalsigns}} {{ title | replace: "\", "-" }} {% if xdepth == 4 %} <<expg.{{ thing_prefix }},image:../templates/expg.gif[]>> {% endif %} ((({{ anchor }},Object definition)))
 
 //equalsigns: {{equalsigns}}
 //


### PR DESCRIPTION
As requested in https://github.com/metanorma/iso-10303-detached-docs/issues/259#issuecomment-1849102148