### PR TITLE
Correct annex identifier from resource templates

### DIFF
--- a/resources/_attribute_definitions.liquid
+++ b/resources/_attribute_definitions.liquid
@@ -35,7 +35,9 @@ endfor
       thing.id != "__note" and
       thing.id != "__example" and
       thing.id != "__figure" %}
-{% unless thing.remarks[0] contains "(output)" %}
+{% unless thing.id == "return" or
+          thing.id == "RETURN" or
+          thing.id == "RETURNS" %}
 
 [[{{thing_prefix}}.{{thing.id}}]]
 [type=express]

--- a/resources/resource_annex_identifier.adoc
+++ b/resources/resource_annex_identifier.adoc
@@ -20,13 +20,13 @@ ISO/IEC 8824-1, and is described in ISO 10303-1.
 ----
 {% assign selected = context.schemas | where: "selected" %}
 {% for schema in selected %}
-{% assign schemaname = schema.id | replace: "_", "-" | downcase %}
+{% assign schemaname = schema.id | downcase %}
 
-{% if context.schemas.size > 1 %}
+{% if selected.size > 1 %}
 ==== {{ schemaname }} schema identification
 {% endif %}
 
-To provide for unambiguous identification of the **{{ schemaname }}** schema in
+To provide for unambiguous identification of the **{{ schemaname  | replace: "_", "-" }}** schema in
 an open information system, the object identifier
 
 {{ schema.version.value }}


### PR DESCRIPTION
This is a correction in the template that generates Annex B from resource documents.
