### PR TITLE
Move NOTE 1 referencing code to `_source_code.liquid`

### DIFF
--- a/common_files/_source_code.liquid
+++ b/common_files/_source_code.liquid
@@ -8,4 +8,34 @@
 (*
 --
 
+{% elsif schema and all_schemas %}
+
+{% capture empty_line %}
+
+{% endcapture %}
+
+[underline]#EXPRESS specification:#
+
+[source%unnumbered]
+--
+SCHEMA {{ schema.id -}};
+{{- empty_line -}}
+{%- for interface in schema.interfaces -%}
+{%- assign schema_name = interface.schema.id -%}
+{%- assign ref_schemas = all_schemas | where: "id", schema_name -%}
+{%- assign reference   = ref_schemas[0].remark_items | where: "id", "__published_in" -%}
+{%- assign reference   = reference[0].remarks[0] | replace_regex: ":.+$", "" -%}
+
+{%- if reference == "" -%}
+{%- assign reference = ref_schemas[0].version.value | replace_regex: "^.+?iso standard (\d+) part\((\d+)\) version.+","ISO \1-\2" -%}
+{%- endif -%}
+
+{%- if reference != "" -%}
+-- The {{ interface.schema.id }} is defined in {{ reference }}
+{{ interface.source }}
+{% endif -%}
+
+{% endfor %}
+--
+
 {% endif %}

--- a/resources/_intro.liquid
+++ b/resources/_intro.liquid
@@ -23,8 +23,4 @@ Once that is fixed the following IF statement should be removed and just use {{ 
 
 {% render "templates/common_files/source_code", source: thing.source %}
 
-{% comment %} Encode NOTE 1 {% endcomment %}
-{% render "templates/common_files/referenced_schemas_note", schema: thing, all_schemas: all_schemas %}
-
-{% comment %} Encode NOTE 2 {% endcomment %}
 NOTE: See <<expg.{{ thing.id }}>> for a graphical representation of this schema.

--- a/resources/_intro.liquid
+++ b/resources/_intro.liquid
@@ -21,6 +21,6 @@ Once that is fixed the following IF statement should be removed and just use {{ 
 
 {% render "templates/common_files/body_remarks", remark_items: thing.remark_items %}
 
-{% render "templates/common_files/source_code", source: thing.source %}
+{% render "templates/common_files/source_code", schema: thing, all_schemas: all_schemas %}
 
 NOTE: See <<expg.{{ thing.id }}>> for a graphical representation of this schema.

--- a/resources/_schema.liquid
+++ b/resources/_schema.liquid
@@ -5,7 +5,7 @@
 == {{ schema.id }}
 
 {% comment %}
-Encode schema introductory content
+Introductory content
 {% endcomment %}
 
 {% render "templates/resources/intro", thing: schema, schema_description: true, all_schemas: all_schemas %}
@@ -14,7 +14,7 @@ Encode schema introductory content
 
 
 {% comment %}
-Encode schema definitions
+Schema definitions
 {% endcomment %}
 
 {% render "templates/resources/constants", schema_id: schema.id, things: schema.constants, thing_prefix: root_thing_prefix, depth: 2 %}


### PR DESCRIPTION
Fixes https://github.com/metanorma/iso-10303-templates/issues/61

Result for part 51  (compiled with parts 41 and 43):

![imagen](https://github.com/user-attachments/assets/61a080a2-ef52-434f-9d3e-4311dbac80f3)

(These changes are applied to resource templates only, as I couldn't compile any module document. I didn't try too hard, though. Let me know if these changes are required for module documents as well to try again.)
