### PR TITLE
Update templates to use new data2text feature

### DIFF
--- a/common_files/schemas_bibliographic_xrefs.adoc
+++ b/common_files/schemas_bibliographic_xrefs.adoc
@@ -5,7 +5,7 @@
 // schemas attachments in "Computer interpretable listings" section (usually Annex C).
 // See https://www.metanorma.org/author/topics/collections/cross-referencing/ for more information.
 
-[yaml2text,schemas.yaml,context]
+[data2text,context=schemas.yaml]
 ----
 {% for schema in context.schemas %}
 

--- a/modules/module_annex_change_history.adoc
+++ b/modules/module_annex_change_history.adoc
@@ -262,3 +262,63 @@ The following MIM EXPRESS declarations and interface specifications have been de
 
 {% endfor %}
 ----
+
+////
+
+# Considerations on the design of this Change history template
+
+Changes are tracked from edition 2 forward. Every edition change is conformed by:
+
+- "General" changes from changes.yaml file located at document folder, if it exists.
+- ARM changes, if there are.
+- MIM changes, if there are.
+- Mapping changes, if there are.
+
+On every edition change, there is a "Summary of changes" sub-section, no matter what.
+
+
+## "General" changes from changes.yaml
+
+NOTE: It is said "General" changes to differentiate from the other type of changes (ARM, MIM, and Mapping).
+
+Changes specified in changes.yaml goes after "Summary of changes" first paragraph which is a boilerplate.
+
+Access to changes.yaml is done in the heading of `data2text` block.
+
+
+## ARM changes
+
+ARM changes must be included if `version` item contains: additions, modifications or deletions.
+
+If there are subsequent Mapping changes, this boilerplate should be added at the end:
+
+"In addition, modifications have been made to the mapping specification, the MIM schema and the EXPRESS-G diagrams to reflect and be consistent with the modifications of the ARM."
+
+
+## MIM changes
+
+MIM changes must be included if `version` item contains: additions, `modifications` or deletions.
+
+
+## Mapping changes
+
+If a `mapping.changes.yaml` file exist, changes should be added.
+
+If `changes` array contains more than one item named `change` this boilerplate should be added:
+
+"The following changes have been made to the ARM to MIM mapping:"
+
+* {{ change 1}}
+...
+* {{ change N }}
+
+If `changes` array contains only one item tagged as `description`. No boilerplate should be added.
+
+
+## Sample documents
+1047: contains only "general" changes (i.e. from `changes.yaml`)
+1061: contains ARM, MIM, Mapping, and "general" changes
+1068: contains "general", ARM and MIM changes
+1707: contains ARM, MIM and Mapping changes
+
+////

--- a/modules/module_annex_change_history.adoc
+++ b/modules/module_annex_change_history.adoc
@@ -9,9 +9,8 @@
 This annex documents the history of technical modifications made to
 ISO/TS {docnumber}-{partnumber}.
 
-[data2text,context=schemas.yaml]
+[data2text,context=schemas.yaml,changes_data=changes.yaml]
 ----
-
 {% comment %} Determine file paths {% endcomment %}
 
 {% liquid
@@ -32,7 +31,6 @@ assign ordinal_numbers = ordinal_numbers | split: ", "
 {% liquid
 assign max_version = 2
 
-assign changes_data = changes_path | loadfile: "."
 assign max_changes_ver = changes_data.change_edition.last.version | plus: 0
 if max_changes_ver > max_version
 assign max_version = max_changes_ver

--- a/modules/module_annex_change_history.adoc
+++ b/modules/module_annex_change_history.adoc
@@ -9,66 +9,56 @@
 This annex documents the history of technical modifications made to
 ISO/TS {docnumber}-{partnumber}.
 
-[yaml2text,schemas.yaml,context]
-------
+[data2text,context=schemas.yaml]
+----
+
+{% comment %} Determine file paths {% endcomment %}
+
 {% liquid
 assign path_prefix  = "../../schemas/modules/"
 assign schema_name  = context.schemas.first[1].path | remove: path_prefix | split: "/" | first
 assign changes_path = "changes.yaml"
-assign mapping_path = schema_name | prepend: path_prefix | append: "/mapping.changes.yaml"
-assign arm_path     = schema_name | prepend: path_prefix | append: "/arm.changes.yaml"
-assign mim_path     = schema_name | prepend: path_prefix | append: "/mim.changes.yaml"
+assign mapping_path = schema_name | prepend: path_prefix | append: "/mapping.changes.yaml" | remove: "../../"
+assign arm_path     = schema_name | prepend: path_prefix | append: "/arm.changes.yaml"     | remove: "../../"
+assign mim_path     = schema_name | prepend: path_prefix | append: "/mim.changes.yaml"     | remove: "../../"
 
 assign ordinal_numbers = "zero, " | append: "first, " | append: "second, " | append: "third, " | append: "fourth, " | append: "fifth, " | append: "sixth, " | append: "seventh, " | append: "eighth, " | append: "ninth, " | append: "tenth, " | append: "eleventh, " | append: "twelfth, " | append: "thirteenth, " | append: "fourteenth, " | append: "fifteenth, " | append: "sixteenth, " | append: "sixteenth, " | append: "seventeenth, " | append: "eighteenth, " | append: "nineteenth, " | append: "twentieth"
 
 assign ordinal_numbers = ordinal_numbers | split: ", "
 %}
 
-{% capture arm_end_par %}
-In addition, modifications have been made to the mapping specification, the MIM schema and the EXPRESS-G diagrams to reflect and be consistent with the modifications of the ARM.
-{% endcapture %}
+{% comment %} Determine max_version {% endcomment %}
 
-{% assign max_version = 2 %}
-
-[yaml2text,{{changes_path}},data]
----
 {% liquid
-assign max_changes_ver = data.change_edition.last.version | plus: 0
+assign max_version = 2
+
+assign changes_data = changes_path | loadfile: "."
+assign max_changes_ver = changes_data.change_edition.last.version | plus: 0
 if max_changes_ver > max_version
 assign max_version = max_changes_ver
 endif
-%}
----
 
-[yaml2text,{{mapping_path}},data]
----
-{% liquid
-assign max_mapping_ver = data.change_edition.last.version | plus: 0
+assign arm_data = arm_path | loadfile: "."
+assign max_arm_ver = arm_data.change_edition.last.version | plus: 0
+if max_arm_ver > max_version
+assign max_version = max_arm_ver
+endif
+
+assign mim_data = mim_path | loadfile: "."
+assign max_mim_ver = mim_data.change_edition.last.version | plus: 0
+if max_mim_ver > max_version
+assign max_version = max_mim_ver
+endif
+
+assign mapping_data = mapping_path | loadfile: "."
+assign max_mapping_ver = mapping_data.change_edition.last.version | plus: 0
 if max_mapping_ver > max_version
 assign max_version = max_mapping_ver
 endif
 %}
----
 
-[yaml2text,{{arm_path}},data]
----
-{% liquid
-assign max_arm_ver = data.change_edition.last.version | plus: 0
-if max_arm_ver > max_version
-assign max_version = max_arm_ver
-endif
-%}
----
 
-[yaml2text,{{mim_path}},data]
----
-{% liquid
-assign max_mim_ver = data.change_edition.last.version | plus: 0
-if max_mim_ver > max_version
-assign max_version = max_mim_ver
-endif
-%}
----
+{% comment %} Generate changes {% endcomment %}
 
 {% for ver in (2..max_version) %}
 
@@ -82,33 +72,34 @@ endif
 
 The {{ ordinal_numbers[ver] }} edition of this document incorporated the modifications to the {{ ordinal_numbers[ver_before] }} edition listed below.
 
-// changes from changes.yaml
+{% comment %} Changes from changes.yaml {% endcomment %}
 
 {% if max_changes_ver %}
-[yaml2text,{{changes_path}},data]
----
+
+{% comment %} Convert version number to string {% endcomment %}
 {% assign ver_str = ver | append: "" %}
 
-// find version
-{% for ed in data.change_edition %}
+{% comment %} Find version {% endcomment %}
+{% for ed in changes_data.change_edition %}
 {% if ed.version == ver_str %}
 {{ ed.description }}
 {% endif %}
 {% endfor %}
----
+
 {% endif %}
 
-// ARM schema changes
+{% comment %} Changes from ARM {% endcomment %}
 
 {% if max_arm_ver %}
-[yaml2text,{{arm_path}},data]
-----
+
+{% comment %} Convert version number to string {% endcomment %}
 {% assign ver_str = ver | append: "" %}
 
-{% for ed in data.change_edition %}
+{% for ed in arm_data.change_edition %}
 
-// find version
 {% if ed.version == ver_str %}
+{% if ed.additions or ed.modifications or ed.deletions %}
+{% assign changes_arm_exist = true %}
 
 [[arm.changes{{ver}}]]
 ==== Changes made to the ARM
@@ -158,55 +149,64 @@ The following ARM EXPRESS declarations and interface specifications have been de
 {% endif %}
 
 {% endif %}
+{% endif %}
 
 {% endfor %}
 
-----
+{% if changes_arm_exist and max_mapping_ver %}
 
-{{ arm_end_par }}
+In addition, modifications have been made to the mapping specification, the MIM schema and the EXPRESS-G diagrams to reflect and be consistent with the modifications of the ARM.
+
+{% assign changes_arm_exist = false %}
+{% endif %}
 
 {% endif %}
 
 
-// mapping changes
+{% comment %} Changes from Mapping {% endcomment %}
 
 {% if max_mapping_ver %}
-[yaml2text,{{mapping_path}},data]
-----
+
 {% assign ver_str = ver | append: "" %}
 
-{% for ed in data.change_edition %}
+{% for ed in mapping_data.change_edition %}
 
-// find version
+{% comment %} Find version {% endcomment %}
 {% if ed.version == ver_str %}
 
 [[mapping.changes{{ver}}]]
 ==== Changes made to the mapping
 
+{% if ed.changes.size == 1 %}
+
+{{ ed.changes[0].description }}
+
+{% else %}
+
 The following changes have been made to the ARM to MIM mapping:
 
-{% for change in ed.changes %}
-
-* {{ change.change }}
-
+{% for item in ed.changes %}
+* {{ item.change }}
 {% endfor %}
 
 {% endif %}
+
+{% endif %}
 {% endfor %}
-----
+
 {% endif %}
 
-// MIM schema changes
+
+{% comment %} Changes from MIM {% endcomment %}
 
 {% if max_mim_ver %}
-[yaml2text,{{mim_path}},data]
-----
 {% assign ver_str = ver | append: "" %}
 
-{% for ed in data.change_edition %}
+{% for ed in mim_data.change_edition %}
 
-// find version
+{% comment %} Find version {% endcomment %}
 {% if ed.version == ver_str %}
+{% if ed.additions or ed.modifications or ed.deletions %}
 
 [[mim.changes{{ver}}]]
 ==== Changes made to the MIM
@@ -256,10 +256,11 @@ The following MIM EXPRESS declarations and interface specifications have been de
 {% endif %}
 
 {% endif %}
-
-{% endfor %}
-----
 {% endif %}
 
 {% endfor %}
-------
+
+{% endif %}
+
+{% endfor %}
+----

--- a/modules/module_annex_diagrams_arm.adoc
+++ b/modules/module_annex_diagrams_arm.adoc
@@ -23,7 +23,7 @@ Both these representations are partial. The schema level representation does not
 
 The EXPRESS-G graphical notation is defined in ISO 10303-11.
 
-[yaml2text,express-g-diagrams-arm.yaml,diagrams]
+[data2text,diagrams=express-g-diagrams-arm.yaml]
 ----
 {% assign namespace = "arm" %}
 include::../common_files/diagrams.liquid[]

--- a/modules/module_annex_diagrams_mim.adoc
+++ b/modules/module_annex_diagrams_mim.adoc
@@ -23,7 +23,7 @@ Both these representations are partial. The schema level representation does not
 
 The EXPRESS-G graphical notation is defined in ISO 10303-11.
 
-[yaml2text,express-g-diagrams-mim.yaml,diagrams]
+[data2text,diagrams=express-g-diagrams-mim.yaml]
 ----
 {% assign namespace = "mim" %}
 include::../common_files/diagrams.liquid[]

--- a/resources/resource_annex_change_history.adoc
+++ b/resources/resource_annex_change_history.adoc
@@ -15,10 +15,10 @@ Unless otherwise specified all modifications are upwardly compatible to the prev
 
 * the mapping tables of ISO 10303 application protocols based on the previous edition of this document remain valid in a revision of that application protocol based on this edition of this document.
 
-[yaml2text,schemas.yaml,context]
+[data2text,context=schemas.yaml]
 ------
 {% liquid
-assign path_prefix = "../../schemas/resources/"
+assign path_prefix = "schemas/resources/"
 assign path_suffix = ".changes.yaml"
 
 for schema in context.schemas
@@ -33,8 +33,9 @@ assign max_version = 2
 {% assign existing_paths = "" %}
 
 {% for path in changes_paths %}
-[yaml2text,{{path}},data]
----
+
+{% assign data = path | loadfile: "." %}
+
 {% liquid
 assign max_change_ver = data.change_edition.last.version | plus: 0
 if max_change_ver > max_version
@@ -43,7 +44,7 @@ endif
 
 assign existing_paths = existing_paths | append: " " | append: path
 %}
----
+
 {% endfor %}
 
 {% assign existing_paths = existing_paths | split: " " %}
@@ -60,8 +61,8 @@ The edition {{ ver }} of this document incorporated the modifications to the edi
 
 {% for path in existing_paths %}
 
-[yaml2text,{{path}},data]
-----
+{% assign data = path | loadfile: "." %}
+
 {% assign ver_str = ver | append: "" %}
 
 {% for ed in data.change_edition %}
@@ -123,7 +124,6 @@ The following EXPRESS declarations and interface specifications have been delete
 {% endif %}
 
 {% endfor %}
-----
 
 {% endfor %}
 

--- a/resources/resource_annex_listings.adoc
+++ b/resources/resource_annex_listings.adoc
@@ -13,7 +13,7 @@ Short names: http://standards.iso.org/iso/10303/tech/short_names/short-names.txt
 
 EXPRESS: http://standards.iso.org/iso/10303/smrl/v11/tech/smrlv11.zip
 
-[yaml2text,schemas.yaml,data]
+[data2text,data=schemas.yaml]
 ----
 [[table_listing]]
 [cols="a,a",options="header"]


### PR DESCRIPTION
Pending update in `modules/module_annex_change_history.adoc` file

UPDATE:

I've finished the updates, but I still need a solution for accessing to `documents/iso-10303-*/changes.yaml` data via `loadfile`. More details in https://github.com/metanorma/metanorma-plugin-datastruct/issues/67. Ping @kwkwan.